### PR TITLE
Removed stream args from beta.chat.completions.parse in OpenAI API

### DIFF
--- a/src/vision_parse/llm.py
+++ b/src/vision_parse/llm.py
@@ -490,7 +490,6 @@ class LLM:
                             messages=messages,
                             temperature=0.0,
                             top_p=0.4,
-                            stream=False,
                             **self.kwargs,
                         )
                     return response.choices[0].message.content
@@ -522,7 +521,6 @@ class LLM:
                             messages=messages,
                             temperature=0.0,
                             top_p=0.4,
-                            stream=False,
                             **self.kwargs,
                         )
                     return response.choices[0].message.content


### PR DESCRIPTION
# What does this PR do?

Removes `stream=False` parameter from OpenAI's structured response API

- [x] Addresses issue (#23)


## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Ran make lint and make format to handle lint / formatting issues.
- [x] Ran make test to run relevant tests scripts.
- [x] Read the [contributor guidelines](https://github.com/iamarunbrahma/vision-parse/blob/main/CONTRIBUTING.md).
- [ ] Wrote necessary unit or integration tests.